### PR TITLE
Optionally bind to the specified address

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ proto.listen = function(port, cb) {
             var info = parser(msg, rinfo)
             me.handler(info)
         })
-        .bind(port)
+        .bind(port, this.opt.address )
 
     return this
 }


### PR DESCRIPTION
Resolves #2 by adding an option to bind to a given interface.  If this option is absent then the socket will continue to be bound on all interfaces.  Verified via positive and negative tests with the command `sudo lsof -i -n -l |grep <port#>`. 
